### PR TITLE
Merge dpvalles/gke-mcp to mauriciopoppe/gke-mcp

### DIFF
--- a/pkg/install/GEMINI.md
+++ b/pkg/install/GEMINI.md
@@ -203,6 +203,15 @@ To identify if there are node registration issues in a GKE node or a nodepool.
 1. **Identify node registration issues**: Use the tool `configure_helper_logs` to identify if there's a configure issue, also use the tool `node_registration_logs` to identify if there's a node registration issue, also use the tool `kubelet_logs` to identify if there issues in the kubelet startup. If the user doesn't provide the parameter `instance` then ask for it.
 1. **Identify nodepool registration issues**: Use the tool `get_nodepool_instances` to get the nodepool instances, and then for every instance identify node registration issues.
 
+ ### Known errors in kubelet logs
+
+1. **Check for known errors in logs**: Use the `kubelet_logs` tool to scan for a list of known errors. If the user doesn't provide the `instance` parameter, be sure to ask for it.
+
+   Some of the errors to look for include:
+   - "failed to open any tpm device"
+
+2. If any errors are found, display them to the user and suggest possible troubleshooting steps.
+
 ## GKE Cluster Known Issues
 
 ### Objective

--- a/pkg/install/GEMINI.md
+++ b/pkg/install/GEMINI.md
@@ -205,12 +205,19 @@ To identify if there are node registration issues in a GKE node or a nodepool.
 
  ### Known errors in kubelet logs
 
-1. **Check for known errors in logs**: Use the `kubelet_logs` tool to scan for a list of known errors. If the user doesn't provide the `instance` parameter, be sure to ask for it.
+1.  **Check for known errors in logs**: Use the `kubelet_logs` tool to scan for a list of known errors. If the user doesn't provide the `instance` parameter, be sure to ask for it.
+  - Some of the errors to look for include:
+    - "failed to open any tpm device"
 
-   Some of the errors to look for include:
-   - "failed to open any tpm device"
+2.  If any errors are found, display them to the user and suggest possible troubleshooting steps.
 
-2. If any errors are found, display them to the user and suggest possible troubleshooting steps.
+### Known errors in node registration checker
+
+1.  **Check for known errors in logs**: Use the `node_registration_logs` tool to scan for a list of known errors. If the user doesn't provide the `instance` parameter, be sure to ask for it.
+  - Some of the errors to look for include:
+    - "Not able to confirm if the node is ready - Collecting information"
+
+2.  If any errors are found, display them to the user and suggest possible troubleshooting steps.
 
 ## GKE Cluster Known Issues
 

--- a/pkg/tools/cluster/cluster.go
+++ b/pkg/tools/cluster/cluster.go
@@ -242,7 +242,7 @@ func (h *handlers) getConfigureHelperLogs(ctx context.Context, request mcp.CallT
 
 	var resultBuilder strings.Builder
 	if foundPattern {
-		resultBuilder.WriteString("The node health checker was unable to confirm if the node is ready\n")
+		resultBuilder.WriteString("The node registration checker was unable to confirm if the node is ready\n")
 	}
 
 	if len(filteredLogs) > 0 {

--- a/pkg/tools/cluster/cluster.go
+++ b/pkg/tools/cluster/cluster.go
@@ -315,15 +315,19 @@ func (h *handlers) getKubeletLogs(ctx context.Context, request mcp.CallToolReque
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	var resultBuilder strings.Builder
+	filteredLogs := []string{}
 	for _, logEntry := range strings.Split(strings.TrimSpace(contents), "\n") {
 		if strings.Contains(logEntry, "kubelet[") {
-			resultBuilder.WriteString(logEntry)
+			filteredLogs = append(filteredLogs, logEntry)
 		}
 	}
 
-	if resultBuilder.Len() > 0 {
-		return mcp.NewToolResultText(resultBuilder.String()), nil
+	if len(filteredLogs) > 0 {
+		output, err := json.MarshalIndent(filteredLogs, "", "  ")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		return mcp.NewToolResultText(string(output)), nil
 	}
 
 	return mcp.NewToolResultText("There are no kubelet logs, this might signal a problem in the VM boot process."), nil

--- a/pkg/tools/cluster/cluster.go
+++ b/pkg/tools/cluster/cluster.go
@@ -143,6 +143,16 @@ func Install(ctx context.Context, s *server.MCPServer, c *config.Config) error {
 	)
 	s.AddTool(configureHelperLogs, h.getConfigureHelperLogs)
 
+	checkConfigureHelperErrorsTool := mcp.NewTool("check_node_registration_checker_errors",
+		mcp.WithDescription("Checks for known errors in configure helper logs"),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithString("project_id", mcp.Required(), mcp.Description("GCP project ID.")),
+		mcp.WithString("zone", mcp.Required(), mcp.Description("GCE instance zone.")),
+		mcp.WithString("instance", mcp.Required(), mcp.Description("GCE instance name.")),
+	)
+	s.AddTool(checkConfigureHelperErrorsTool, h.checkNodeRegistrationCheckerErrors)
+
 	getNodePoolInstancesTool := mcp.NewTool("get_nodepool_instances",
 		mcp.WithDescription("Get the instances controlled by a nodepool"),
 		mcp.WithReadOnlyHintAnnotation(true),
@@ -232,19 +242,10 @@ func (h *handlers) getConfigureHelperLogs(ctx context.Context, request mcp.CallT
 	}
 
 	filteredLogs := []string{}
-	foundPattern := false
 	for _, logEntry := range strings.Split(strings.TrimSpace(contents), "\n") {
 		if strings.Contains(logEntry, "configure.sh") || strings.Contains(logEntry, "configure-helper.sh") {
 			filteredLogs = append(filteredLogs, logEntry)
 		}
-		if !foundPattern && strings.Contains(logEntry, "Not able to confirm if the node is ready - Collecting information") {
-			foundPattern = true
-		}
-	}
-
-	var resultBuilder strings.Builder
-	if foundPattern {
-		resultBuilder.WriteString("The node registration checker was unable to confirm if the node is ready\n")
 	}
 
 	if len(filteredLogs) > 0 {
@@ -252,14 +253,36 @@ func (h *handlers) getConfigureHelperLogs(ctx context.Context, request mcp.CallT
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
-		resultBuilder.Write(output)
-	}
-
-	if resultBuilder.Len() > 0 {
-		return mcp.NewToolResultText(resultBuilder.String()), nil
+		return mcp.NewToolResultText(string(output)), nil
 	}
 
 	return mcp.NewToolResultText("There are no configure.sh logs, this might signal a problem in the VM boot process."), nil
+}
+
+func (h *handlers) checkNodeRegistrationCheckerErrors(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	projectID, err := request.RequireString("project_id")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	zone, err := request.RequireString("zone")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	instance, err := request.RequireString("instance")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	contents, err := h.getSerialPortLogs(ctx, projectID, zone, instance, 3)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	if strings.Contains(contents, "Not able to confirm if the node is ready - Collecting information") {
+		return mcp.NewToolResultText("The node registration checker was unable to confirm if the node is ready"), nil
+	}
+
+	return mcp.NewToolResultText("No known errors found in configure helper logs."), nil
 }
 
 func (h *handlers) getSerialPortOutput(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -378,7 +401,7 @@ func (h *handlers) checkKubeletErrors(ctx context.Context, request mcp.CallToolR
 	var resultBuilder strings.Builder
 	for pattern, errorMessage := range knownErrors {
 		if strings.Contains(contents, pattern) {
-			resultBuilder.WriteString(errorMessage)
+			resultBuilder.WriteString(fmt.Sprintf("%s\n", errorMessage))
 		}
 	}
 

--- a/pkg/tools/cluster/cluster.go
+++ b/pkg/tools/cluster/cluster.go
@@ -123,16 +123,6 @@ func Install(ctx context.Context, s *server.MCPServer, c *config.Config) error {
 	)
 	s.AddTool(kubeletLogs, h.getKubeletLogs)
 
-	checkKubeletErrorsTool := mcp.NewTool("check_kubelet_errors",
-		mcp.WithDescription("Checks for known errors in kubelet logs"),
-		mcp.WithReadOnlyHintAnnotation(true),
-		mcp.WithIdempotentHintAnnotation(true),
-		mcp.WithString("project_id", mcp.Required(), mcp.Description("GCP project ID.")),
-		mcp.WithString("zone", mcp.Required(), mcp.Description("GCE instance zone.")),
-		mcp.WithString("instance", mcp.Required(), mcp.Description("GCE instance name.")),
-	)
-	s.AddTool(checkKubeletErrorsTool, h.checkKubeletErrors)
-
 	configureHelperLogs := mcp.NewTool("configure_helper_logs",
 		mcp.WithDescription("Gets configure helper logs from a GKE node serial output"),
 		mcp.WithReadOnlyHintAnnotation(true),
@@ -373,43 +363,6 @@ func (h *handlers) getKubeletLogs(ctx context.Context, request mcp.CallToolReque
 	}
 
 	return mcp.NewToolResultText("There are no kubelet logs, this might signal a problem in the VM boot process."), nil
-}
-
-func (h *handlers) checkKubeletErrors(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	projectID, err := request.RequireString("project_id")
-	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
-	}
-	zone, err := request.RequireString("zone")
-	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
-	}
-	instance, err := request.RequireString("instance")
-	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
-	}
-
-	contents, err := h.getSerialPortLogs(ctx, projectID, zone, instance, 3)
-	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
-	}
-
-	knownErrors := map[string]string{
-		"failed to open any tpm device": "TPM device not found. This can happen on nodes that do not have a Trusted Platform Module.",
-	}
-
-	var resultBuilder strings.Builder
-	for pattern, errorMessage := range knownErrors {
-		if strings.Contains(contents, pattern) {
-			resultBuilder.WriteString(fmt.Sprintf("%s\n", errorMessage))
-		}
-	}
-
-	if resultBuilder.Len() > 0 {
-		return mcp.NewToolResultText(resultBuilder.String()), nil
-	}
-
-	return mcp.NewToolResultText("No known errors found in kubelet logs."), nil
 }
 
 func (h *handlers) getSerialPortLogs(ctx context.Context, projectID, zone, instance string, port int32) (string, error) {

--- a/pkg/tools/cluster/cluster.go
+++ b/pkg/tools/cluster/cluster.go
@@ -228,11 +228,21 @@ func (h *handlers) getConfigureHelperLogs(ctx context.Context, request mcp.CallT
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
+	contents := resp.GetContents()
 	filteredLogs := []string{}
-	for _, logEntry := range strings.Split(strings.TrimSpace(resp.GetContents()), "\n") {
+	foundPattern := false
+	for _, logEntry := range strings.Split(strings.TrimSpace(contents), "\n") {
 		if strings.Contains(logEntry, "configure.sh") || strings.Contains(logEntry, "configure-helper.sh") {
 			filteredLogs = append(filteredLogs, logEntry)
 		}
+		if !foundPattern && strings.Contains(logEntry, "Not able to confirm if the node is ready - Collecting information") {
+			foundPattern = true
+		}
+	}
+
+	var resultBuilder strings.Builder
+	if foundPattern {
+		resultBuilder.WriteString("The node health checker was unable to confirm if the node is ready\n")
 	}
 
 	if len(filteredLogs) > 0 {
@@ -240,7 +250,11 @@ func (h *handlers) getConfigureHelperLogs(ctx context.Context, request mcp.CallT
 		if err != nil {
 			return mcp.NewToolResultError(err.Error()), nil
 		}
-		return mcp.NewToolResultText(string(output)), nil
+		resultBuilder.Write(output)
+	}
+
+	if resultBuilder.Len() > 0 {
+		return mcp.NewToolResultText(resultBuilder.String()), nil
 	}
 
 	return mcp.NewToolResultText("There are no configure.sh logs, this might signal a problem in the VM boot process."), nil

--- a/pkg/tools/cluster/cluster.go
+++ b/pkg/tools/cluster/cluster.go
@@ -133,16 +133,6 @@ func Install(ctx context.Context, s *server.MCPServer, c *config.Config) error {
 	)
 	s.AddTool(configureHelperLogs, h.getConfigureHelperLogs)
 
-	checkConfigureHelperErrorsTool := mcp.NewTool("check_node_registration_checker_errors",
-		mcp.WithDescription("Checks for known errors in configure helper logs"),
-		mcp.WithReadOnlyHintAnnotation(true),
-		mcp.WithIdempotentHintAnnotation(true),
-		mcp.WithString("project_id", mcp.Required(), mcp.Description("GCP project ID.")),
-		mcp.WithString("zone", mcp.Required(), mcp.Description("GCE instance zone.")),
-		mcp.WithString("instance", mcp.Required(), mcp.Description("GCE instance name.")),
-	)
-	s.AddTool(checkConfigureHelperErrorsTool, h.checkNodeRegistrationCheckerErrors)
-
 	getNodePoolInstancesTool := mcp.NewTool("get_nodepool_instances",
 		mcp.WithDescription("Get the instances controlled by a nodepool"),
 		mcp.WithReadOnlyHintAnnotation(true),
@@ -247,32 +237,6 @@ func (h *handlers) getConfigureHelperLogs(ctx context.Context, request mcp.CallT
 	}
 
 	return mcp.NewToolResultText("There are no configure.sh logs, this might signal a problem in the VM boot process."), nil
-}
-
-func (h *handlers) checkNodeRegistrationCheckerErrors(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	projectID, err := request.RequireString("project_id")
-	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
-	}
-	zone, err := request.RequireString("zone")
-	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
-	}
-	instance, err := request.RequireString("instance")
-	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
-	}
-
-	contents, err := h.getSerialPortLogs(ctx, projectID, zone, instance, 3)
-	if err != nil {
-		return mcp.NewToolResultError(err.Error()), nil
-	}
-
-	if strings.Contains(contents, "Not able to confirm if the node is ready - Collecting information") {
-		return mcp.NewToolResultText("The node registration checker was unable to confirm if the node is ready"), nil
-	}
-
-	return mcp.NewToolResultText("No known errors found in configure helper logs."), nil
 }
 
 func (h *handlers) getSerialPortOutput(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/pkg/tools/cluster/cluster.go
+++ b/pkg/tools/cluster/cluster.go
@@ -123,6 +123,16 @@ func Install(ctx context.Context, s *server.MCPServer, c *config.Config) error {
 	)
 	s.AddTool(kubeletLogs, h.getKubeletLogs)
 
+	checkKubeletErrorsTool := mcp.NewTool("check_kubelet_errors",
+		mcp.WithDescription("Checks for known errors in kubelet logs"),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithString("project_id", mcp.Required(), mcp.Description("GCP project ID.")),
+		mcp.WithString("zone", mcp.Required(), mcp.Description("GCE instance zone.")),
+		mcp.WithString("instance", mcp.Required(), mcp.Description("GCE instance name.")),
+	)
+	s.AddTool(checkKubeletErrorsTool, h.checkKubeletErrors)
+
 	configureHelperLogs := mcp.NewTool("configure_helper_logs",
 		mcp.WithDescription("Gets configure helper logs from a GKE node serial output"),
 		mcp.WithReadOnlyHintAnnotation(true),
@@ -216,19 +226,11 @@ func (h *handlers) getConfigureHelperLogs(ctx context.Context, request mcp.CallT
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	var portI32 int32 = int32(3)
-	req := &computepb.GetSerialPortOutputInstanceRequest{
-		Project:  projectID,
-		Zone:     zone,
-		Instance: instance,
-		Port:     &portI32,
-	}
-	resp, err := h.gceClient.GetSerialPortOutput(ctx, req)
+	contents, err := h.getSerialPortLogs(ctx, projectID, zone, instance, 3)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	contents := resp.GetContents()
 	filteredLogs := []string{}
 	foundPattern := false
 	for _, logEntry := range strings.Split(strings.TrimSpace(contents), "\n") {
@@ -273,17 +275,11 @@ func (h *handlers) getSerialPortOutput(ctx context.Context, request mcp.CallTool
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
-	req := &computepb.GetSerialPortOutputInstanceRequest{
-		Project:  projectID,
-		Zone:     zone,
-		Instance: instance,
-	}
-	resp, err := h.gceClient.GetSerialPortOutput(ctx, req)
+	contents, err := h.getSerialPortLogs(ctx, projectID, zone, instance, 1)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
-
-	return mcp.NewToolResultText(resp.GetContents()), nil
+	return mcp.NewToolResultText(contents), nil
 }
 
 func (h *handlers) getNodeRegistrationLogs(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -300,18 +296,13 @@ func (h *handlers) getNodeRegistrationLogs(ctx context.Context, request mcp.Call
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	req := &computepb.GetSerialPortOutputInstanceRequest{
-		Project:  projectID,
-		Zone:     zone,
-		Instance: instance,
-	}
-	resp, err := h.gceClient.GetSerialPortOutput(ctx, req)
+	contents, err := h.getSerialPortLogs(ctx, projectID, zone, instance, 1)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
 	filteredLogs := []string{}
-	for _, logEntry := range strings.Split(strings.TrimSpace(resp.GetContents()), "\n") {
+	for _, logEntry := range strings.Split(strings.TrimSpace(contents), "\n") {
 		if strings.Contains(logEntry, "node-registration-checker.sh") {
 			filteredLogs = append(filteredLogs, logEntry)
 		}
@@ -342,34 +333,74 @@ func (h *handlers) getKubeletLogs(ctx context.Context, request mcp.CallToolReque
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	var portI32 int32 = int32(3)
-	req := &computepb.GetSerialPortOutputInstanceRequest{
-		Project:  projectID,
-		Zone:     zone,
-		Instance: instance,
-		Port:     &portI32,
-	}
-	resp, err := h.gceClient.GetSerialPortOutput(ctx, req)
+	contents, err := h.getSerialPortLogs(ctx, projectID, zone, instance, 3)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
 	}
 
-	filteredLogs := []string{}
-	for _, logEntry := range strings.Split(strings.TrimSpace(resp.GetContents()), "\n") {
+	var resultBuilder strings.Builder
+	for _, logEntry := range strings.Split(strings.TrimSpace(contents), "\n") {
 		if strings.Contains(logEntry, "kubelet[") {
-			filteredLogs = append(filteredLogs, logEntry)
+			resultBuilder.WriteString(logEntry)
 		}
 	}
 
-	if len(filteredLogs) > 0 {
-		output, err := json.MarshalIndent(filteredLogs, "", "  ")
-		if err != nil {
-			return mcp.NewToolResultError(err.Error()), nil
-		}
-		return mcp.NewToolResultText(string(output)), nil
+	if resultBuilder.Len() > 0 {
+		return mcp.NewToolResultText(resultBuilder.String()), nil
 	}
 
 	return mcp.NewToolResultText("There are no kubelet logs, this might signal a problem in the VM boot process."), nil
+}
+
+func (h *handlers) checkKubeletErrors(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	projectID, err := request.RequireString("project_id")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	zone, err := request.RequireString("zone")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+	instance, err := request.RequireString("instance")
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	contents, err := h.getSerialPortLogs(ctx, projectID, zone, instance, 3)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), nil
+	}
+
+	knownErrors := map[string]string{
+		"failed to open any tpm device": "TPM device not found. This can happen on nodes that do not have a Trusted Platform Module.",
+	}
+
+	var resultBuilder strings.Builder
+	for pattern, errorMessage := range knownErrors {
+		if strings.Contains(contents, pattern) {
+			resultBuilder.WriteString(errorMessage)
+		}
+	}
+
+	if resultBuilder.Len() > 0 {
+		return mcp.NewToolResultText(resultBuilder.String()), nil
+	}
+
+	return mcp.NewToolResultText("No known errors found in kubelet logs."), nil
+}
+
+func (h *handlers) getSerialPortLogs(ctx context.Context, projectID, zone, instance string, port int32) (string, error) {
+	req := &computepb.GetSerialPortOutputInstanceRequest{
+		Project:  projectID,
+		Zone:     zone,
+		Instance: instance,
+		Port:     &port,
+	}
+	resp, err := h.gceClient.GetSerialPortOutput(ctx, req)
+	if err != nil {
+		return "", err
+	}
+	return resp.GetContents(), nil
 }
 
 func (h *handlers) listClusters(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {


### PR DESCRIPTION
- The getConfigureHelperLogs() checks for the "not able to confirm if the node is ready - Collecting information" message
- Implement a way to showcase kubelet errors with the tool `check_kubelet_errors`